### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Example repository for using GAP on Binder
 
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/gap-system/gap-docker-stable-4.11/master)
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/gap-system/gap-docker/master)
 
 This repository should show you how to use deploy [GAP](https://wwww.gap-system.org) Jupyter notebooks to Binder.
 If you simply want to try out GAP on mybinder.org, you can click the launch badge above.
@@ -8,9 +8,8 @@ If you simply want to try out GAP on mybinder.org, you can click the launch badg
 ## Using existing jupyter notebooks
 
 GAP provides several Binder-ready Docker images, for example:
-- [gapsystem/gap-docker](https://hub.docker.com/r/gapsystem/gap-docker/)
-- [gapsystem/gap-docker-stable-4.11](https://hub.docker.com/r/gapsystem/gap-docker-stable-4.11/)
-- [gapsystem/gap-docker-master](https://hub.docker.com/r/gapsystem/gap-docker-master/)
+- for the latest GAP release [gap-system/gap-docker](https://hub.docker.com/r/gapsystem/gap-docker/)
+- for the GAP development version [gap-system/gap-docker-master](https://hub.docker.com/r/gapsystem/gap-docker-master/)
 
 Is is based on the current master branch of GAP.
 To use for example the 4.11 image to deploy your notebook to Binder, use the following steps:

--- a/README.md
+++ b/README.md
@@ -1,17 +1,22 @@
 # Example repository for using GAP on Binder
 
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/gap-system/gap-docker-binder/master)
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/gap-system/gap-docker-stable-4.11/master)
 
 This repository should show you how to use deploy [GAP](https://wwww.gap-system.org) Jupyter notebooks to Binder.
+If you simply want to try out GAP on mybinder.org, you can click the launch badge above.
 
-## Using GAP on Binder
+## Using existing jupyter notebooks
 
-GAP provides a Binder-ready Docker image: [gapsystem/gap-docker-master](https://hub.docker.com/r/gapsystem/gap-docker-master/). 
+GAP provides several Binder-ready Docker images, for example:
+- [gapsystem/gap-docker](https://hub.docker.com/r/gapsystem/gap-docker/)
+- [gapsystem/gap-docker-stable-4.11](https://hub.docker.com/r/gapsystem/gap-docker-stable-4.11/)
+- [gapsystem/gap-docker-master](https://hub.docker.com/r/gapsystem/gap-docker-master/)
+
 Is is based on the current master branch of GAP.
-To use this image to deploy your repository to Binder, use the following steps:
+To use for example the 4.11 image to deploy your notebook to Binder, use the following steps:
 
 1. Create a new `git`-Repository on [GitHub](https://github.com).
-2. Copy the [Dockerfile](TODO) from this repository into the folder you have cloned or created the `git` repository in.
+2. Copy the [Dockerfile](https://github.com/gap-system/gap-docker-stable-4.11/blob/master/Dockerfile) from the [gapsystem/gap-docker-stable-4.11](https://hub.docker.com/r/gapsystem/gap-docker-stable-4.11/) repository into your newly created `git` repository.
 3. Copy your Jupyter notebooks into the repository.
 4. Upload the repository to GitHub.
 5. Copy the link to the repository and launch it on [MyBinder](https://mybinder.org) or any Binder instance of your choice.


### PR DESCRIPTION
Clarify the instructions and set the binder launch badge to link to a GAP 4.11. The current linker doesn't work on mybinder.org for me.

Also fix a missing link.